### PR TITLE
pull go-ipfs from edge repos in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,13 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,12 +14,13 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,12 +14,13 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \


### PR DESCRIPTION
This will ingest the latest versions of the go-bin for IPFS, the one in 3.12 is pretty behind, we should not need to babysit this either, going forward we should always pull from edge regardless of rebasing.