### PR TITLE
use ipfs stable for arm32

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,13 +14,12 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
+	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
- apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \


### PR DESCRIPTION
Looks like .7 is broken on arm32, it is calling for 64 bit symbols which cannot exist on that platform. .5 still works though. Going to hold back armhf. 