### PR TITLE
rebase to alpine 3.13 stop pulling from edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:3.13
 
 # set version label
 ARG BUILD_DATE
@@ -14,13 +14,12 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
+	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
- apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.13
 
 # set version label
 ARG BUILD_DATE
@@ -14,13 +14,12 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
+	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
- apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.12
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -241,4 +241,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.02.20:** - Rebase to Alpine 3.13.
 * **09.07.19:** - Initial version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,4 +50,5 @@ app_setup_block: |
    
 # changelog
 changelogs:
+  - { date: "24.02.20:", desc: "Rebase to Alpine 3.13." }
   - { date: "09.07.19:", desc: "Initial version." }


### PR DESCRIPTION
Rebase to Alpine 3.13 and stop pulling from edge. Pins this to v.7 IPFS until they have migration bins. 
https://github.com/linuxserver/docker-ipfs/issues/4