### PR TITLE
include fs-repo migration bins to support upgrading to latest IPFS

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,3 +1,27 @@
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.13 as migration-bins
+
+RUN \
+ echo "**** install buid packages ****" && \
+ apk add --no-cache \
+	curl \
+	gcc \
+	git \
+	go \
+	musl-dev && \
+ echo "**** build fs-repo-migrations ****" && \
+ mkdir /bins && \
+ IPFSMIG_VERSION=$(curl -sX GET "https://api.github.com/repos/ipfs/fs-repo-migrations/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone https://github.com/ipfs/fs-repo-migrations.git && \
+ cd fs-repo-migrations && \
+ git checkout ${IPFSMIG_VERSION} && \
+ for BUILD in fs-repo-migrations fs-repo-9-to-10 fs-repo-10-to-11; do \
+	cd ${BUILD} && \
+	go build && \
+	mv fs-repo-* /bins/ && \
+	cd .. ; \
+ done
+ 
 FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.13
 
 # set version label
@@ -14,12 +38,13 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \
@@ -46,6 +71,7 @@ RUN \
 
 # copy files
 COPY root/ /
+COPY --from=migration-bins /bins /usr/bin
 
 # ports and volumes
 EXPOSE 80 443 4001 5001 8080

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,28 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13 as migration-bins
+
+RUN \
+ echo "**** install buid packages ****" && \
+ apk add --no-cache \
+	curl \
+	gcc \
+	git \
+	go \
+	musl-dev && \
+ echo "**** build fs-repo-migrations ****" && \
+ mkdir /bins && \
+ IPFSMIG_VERSION=$(curl -sX GET "https://api.github.com/repos/ipfs/fs-repo-migrations/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+ git clone https://github.com/ipfs/fs-repo-migrations.git && \
+ cd fs-repo-migrations && \
+ git checkout ${IPFSMIG_VERSION} && \
+ for BUILD in fs-repo-migrations fs-repo-9-to-10 fs-repo-10-to-11; do \
+	cd ${BUILD} && \
+	go build && \
+	mv fs-repo-* /bins/ && \
+	cd .. ; \
+ done
+ 
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.13
 
 # set version label
 ARG BUILD_DATE
@@ -14,12 +38,13 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	go-ipfs \
 	logrotate \
 	nginx \
 	openssl \
 	php7 \
 	php7-fpm && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	go-ipfs && \
  echo "**** install ipfs web-ui ****" && \
  mkdir -p /var/www/html/ && \
  if [ -z ${IPFSWEB_VERSION+x} ]; then \
@@ -46,6 +71,7 @@ RUN \
 
 # copy files
 COPY root/ /
+COPY --from=migration-bins /bins /usr/bin
 
 # ports and volumes
 EXPOSE 80 443 4001 5001 8080

--- a/README.md
+++ b/README.md
@@ -241,5 +241,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **01.04.21:** - Add migration bins to image to support upgrades.
 * **24.02.20:** - Rebase to Alpine 3.13.
 * **09.07.19:** - Initial version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,5 +50,6 @@ app_setup_block: |
    
 # changelog
 changelogs:
+  - { date: "01.04.21:", desc: "Add migration bins to image to support upgrades." }
   - { date: "24.02.20:", desc: "Rebase to Alpine 3.13." }
   - { date: "09.07.19:", desc: "Initial version." }

--- a/root/etc/cont-init.d/40-migrate
+++ b/root/etc/cont-init.d/40-migrate
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+# ipfs migrate check on startup
+if [ -d "/config/ipfs" ]; then
+ echo "[ipfs-upgrade] Checking if fs-repo needs to be upgraded (this may take some time)"
+ s6-setuidgid abc /usr/bin/fs-repo-migrations -y
+fi


### PR DESCRIPTION
closes https://github.com/linuxserver/docker-ipfs/issues/4
This is a bit of a band aid but is needed to keep up with the project as their baked in upgrade system has no logic to detect MUSL systems and reaches out to IPFS for pre-built bins to perform the migrations. Currently that will pull down a glibc bin. 
The bins are embedded into the image with this and a migration is run on startup, if none is needed it just exits 0 with a message that you are up to date.
The bins are manually tracked in the Docker file, but it should not be a frequent maintenance thing as the 9-10 and 10-11 has been the only bins needed now for a year or two. 
https://github.com/ipfs/fs-repo-migrations/issues/121
